### PR TITLE
Use python 3.7 during the whole validation process

### DIFF
--- a/env_install.sh
+++ b/env_install.sh
@@ -34,7 +34,7 @@ else [ $simu_env -eq 3 ]
     module use /opt/exp_soft/vo.llr.in2p3.fr/modulefiles_el7/
     # useful in case we rerun only the simulation step
     module purge
-    module load python/3.6.6
+    module load python/3.7.0
     module load compilers/gcc/9.x.x
     source /opt/exp_soft/llr/root/vv6.20.06-el7-gcc9-py37/etc/init.sh
     echo 'Working at LLR in sl7 environment'

--- a/hgctpgvalidation/parameters.py
+++ b/hgctpgvalidation/parameters.py
@@ -43,6 +43,7 @@ class ConfigFileParameters():
     def installWorkingRefDir(self):
         command = 'export SCRAM_ARCH=' + self.scramArch + ';' + \
         'echo $SCRAM_ARCH'  + ';' + \
+        'module purge; ' + \
         'scramv1 p -n ' + self.workingRefDir + ' CMSSW ' + self.releaseRefName + ';' + \
         'cd ' + self.workingRefDir + '/src;' + \
         'echo $PWD; ' + \
@@ -54,6 +55,7 @@ class ConfigFileParameters():
     def installWorkingTestDir(self):
         command = 'export SCRAM_ARCH=' + self.scramArch + ';' + \
         'echo $SCRAM_ARCH'  + ';' + \
+        'module purge; ' + \
         'scramv1 p -n ' + self.workingTestDir + ' CMSSW ' + self.releaseTestName + ';' + \
         'cd ' + self.workingTestDir + '/src;' + \
         'echo $PWD; ' + \
@@ -64,13 +66,13 @@ class ConfigFileParameters():
 
     def runCompileRefStep(self):
         command = 'export SCRAM_ARCH=' + self.scramArch + ';' + \
-        'cd ' + self.workingRefDir + '/src; eval `scramv1 runtime -sh`;' + \
+        'cd ' + self.workingRefDir + '/src; module purge; eval `scramv1 runtime -sh`;' + \
         'scram b -j4; ' + 'echo === End of compilation ===;' + 'echo $PWD;'
         return command
 
     def runCompileTestStep(self):
         command = 'export SCRAM_ARCH=' + self.scramArch + ';' + \
-        'cd ' + self.workingTestDir + '/src; eval `scramv1 runtime -sh`;' + \
+        'cd ' + self.workingTestDir + '/src; module purge; eval `scramv1 runtime -sh`;' + \
         'scram b -j4; ' + 'echo === End of compilation ===;' + 'echo $PWD;'
         return command
 

--- a/scripts/displayHistos.sh
+++ b/scripts/displayHistos.sh
@@ -25,16 +25,12 @@ then
     source /opt/exp_soft/llr/root/v6.06.00-el6-gcc48/etc/init.sh
 else [ $simu_env -eq 3 ]
     # Config at LLR in sl7, python3
-    module use /opt/exp_soft/vo.llr.in2p3.fr/modulefiles_el7/
-    module purge
-    module load python/3.7.0
-    module load compilers/gcc/9.x.x
-    source /opt/exp_soft/llr/root/vv6.20.06-el7-gcc9-py37/etc/init.sh
+     echo 'Config at LLR in sl7'
 fi
 
-echo 'The Python version was changed to '
+echo 'The Python version is: '
 python -V
-echo 'The ROOT version is '
+echo 'The ROOT version is:'
 root-config --version
 
 # Extract Time information for all modules


### PR DESCRIPTION
Added minor changes allowing to use the same python version (python 3.7) during the different stages of the validation.